### PR TITLE
Update convert_mod_schema.php to work with 3.2

### DIFF
--- a/migrations/convert_mod_schema.php
+++ b/migrations/convert_mod_schema.php
@@ -64,7 +64,7 @@ class convert_mod_schema extends \phpbb\db\migration\migration
 		$found_digest_columns = array();
 
 		// The tools class has some convenient methods we will use to add and remove columns
-		$tools = new \phpbb\db\tools($this->db);
+		$tools = new \phpbb\db\tools\tools($this->db);
 
 		// Get a list of the current columns in the phpbb_users table.
 		$user_table_columns = array_keys($tools->sql_list_columns($this->table_prefix . 'users'));


### PR DESCRIPTION
\phpbb\db\tools has been deprecated and moved to \phpbb\db\tools\tools in 3.2. A BC layer was added but will not be made available until 3.2.1.