### PR TITLE
Switch language; require_once

### DIFF
--- a/cron/task/digests.php
+++ b/cron/task/digests.php
@@ -160,7 +160,10 @@ class digests extends \phpbb\cron\task\base
 			$this->user->style['style_parent_id'] = 0;
 			$this->user->style['bbcode_bitfield'] = 'kNg=';
 
-			// phpBB cron and a system cron assumes an interface where styles won't be needed, so it must be told where to find them.
+			// phpBB cron and a system cron assumes an interface where language variables and styles won't be needed, so it must be told where to find them.
+			$this->language->set_user_language($this->config['default_lang'], true); // before user context, use board language
+			$this->language->add_lang('common');
+			$this->language->add_lang(array('common', 'acp/common'), 'phpbbservices/digests');
 			$this->template->set_style(array($this->path_prefix . 'ext/phpbbservices/digests/styles', 'styles'));
 			
 			// How many hours of digests are wanted? We want to do it for the number of hours between now and when digests were last ran successfully.
@@ -284,7 +287,7 @@ class digests extends \phpbb\cron\task\base
 		}
 		if ($this->system_cron)
 		{
-			include($this->path_prefix . 'includes/functions_content.' . $this->phpEx);	// Otherwise censor_text won't be found.
+			require_once $this->path_prefix . 'includes/functions_content.' . $this->phpEx;	// Otherwise censor_text won't be found.
 			$this->phpbb_log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_CONFIG_DIGESTS_SYSTEM_CRON_RUN');
 		}
 		
@@ -589,11 +592,9 @@ class digests extends \phpbb\cron\task\base
 			// If in cron mode, no language files are loaded. Load the appropriate language files based on the user's
 			// preferred language. The board default language is probably English, which may not be what we want since
 			// phpBB supports multiple languages depending on the language packs installed and what the user chooses.
-			if (!$this->manual_mode)
+			if (!$this->manual_mode && $this->user_language != $row['user_lang'])
 			{
 				$this->language->set_user_language($row['user_lang'], true);
-				$this->language->add_lang('common');
-				$this->language->add_lang(array('common', 'acp/common'), 'phpbbservices/digests');
 			}
 
 			$this->toc = array();		// Create or empty the array containing table of contents information

--- a/language/en/email/digests_html.txt
+++ b/language/en/email/digests_html.txt
@@ -85,11 +85,12 @@
 			{L_DIGESTS_BLOCK_IMAGES}{L_COLON} <!-- IF S_DIGESTS_BLOCK_IMAGES -->{L_YES}<!-- ELSE-->{L_NO}<!-- ENDIF--><br />
 			{L_DIGESTS_TOC}{L_COLON} <!-- IF S_DIGESTS_TOC -->{L_YES}<!-- ELSE-->{L_NO}<!-- ENDIF-->
 		</div></blockquote>
-		<hr />
-		<p><span class="copyright"><em>{S_DIGESTS_PUBLISH_DATE}</em></span></p>
-		<p>{S_DIGESTS_DISCLAIMER}</p>
-		<p><span class="copyright">{L_DIGESTS_POWERED_BY_TEXT} {S_DIGESTS_POWERED_BY}{S_DIGESTS_TRANSLATOR}</span></p>
-		
+		<div class="author">
+			<hr />
+			<p><span class="copyright"><em>{S_DIGESTS_PUBLISH_DATE}</em></span></p>
+			<p>{S_DIGESTS_DISCLAIMER}</p>
+			<p><span class="copyright">{L_DIGESTS_POWERED_BY_TEXT} {S_DIGESTS_POWERED_BY}{S_DIGESTS_TRANSLATOR}</span></p>
+		</div>
 	</div>
 </div>
 </body>


### PR DESCRIPTION
When launched from a system cron, the $user object is not initialized. I suggest to set a board forum at the beginning for proper error logging.

Later, when looping over users to send digests to, a small optimization can be done to change the language only in case it is different to the current one.

The language class is clever enough to remember loaded language files (core and extensions), so it is not necessary to call add_lang() again.

The functions_content.php is required also by reparse.php. If called in cron together, it fails on duplicate declaration. Using require_once avoids this.