### PR TITLE
HTML mail format fix

### DIFF
--- a/language/en/email/digests_html.txt
+++ b/language/en/email/digests_html.txt
@@ -85,11 +85,12 @@
 			{L_DIGESTS_BLOCK_IMAGES}{L_COLON} <!-- IF S_DIGESTS_BLOCK_IMAGES -->{L_YES}<!-- ELSE-->{L_NO}<!-- ENDIF--><br />
 			{L_DIGESTS_TOC}{L_COLON} <!-- IF S_DIGESTS_TOC -->{L_YES}<!-- ELSE-->{L_NO}<!-- ENDIF-->
 		</div></blockquote>
-		<hr />
-		<p><span class="copyright"><em>{S_DIGESTS_PUBLISH_DATE}</em></span></p>
-		<p>{S_DIGESTS_DISCLAIMER}</p>
-		<p><span class="copyright">{L_DIGESTS_POWERED_BY_TEXT} {S_DIGESTS_POWERED_BY}{S_DIGESTS_TRANSLATOR}</span></p>
-		
+		<div class="author">
+			<hr />
+			<p><span class="copyright"><em>{S_DIGESTS_PUBLISH_DATE}</em></span></p>
+			<p>{S_DIGESTS_DISCLAIMER}</p>
+			<p><span class="copyright">{L_DIGESTS_POWERED_BY_TEXT} {S_DIGESTS_POWERED_BY}{S_DIGESTS_TRANSLATOR}</span></p>
+		</div>
 	</div>
 </div>
 </body>


### PR DESCRIPTION
Force footer to stay at the bottom even if external CSS is not used. When user's email client blocks external CSS download, the digest footer jumps to the middle of the screen. This can be avoided by putting the footer in a separate DIV tag and reset the "float" status. Compare attached pictures to see the difference. When CSS is downloaded and used, there is no difference.

Wrong (before change):
![mail_wrong](https://cloud.githubusercontent.com/assets/15941148/25697936/35a09e64-30bd-11e7-9757-946a84d674ef.png)

Corrected:
![mail_correct](https://cloud.githubusercontent.com/assets/15941148/25697935/35a0608e-30bd-11e7-9fc3-5d6f42d5794f.png)
