### PR TITLE
use date_loc instead of strftime

### DIFF
--- a/acp/main_module.php
+++ b/acp/main_module.php
@@ -468,8 +468,8 @@ class main_module
 					}
 					else
 					{
-						$user_lastvisit = ($row['user_lastvisit'] == 0) ? $this->language->lang('DIGESTS_NEVER_VISITED') : strftime($this->helper->dateFormatToStrftime($this->user->data['user_dateformat'], $this->user->data['user_lang']), $row['user_lastvisit'] + (60 * 60 * ($my_time_zone - (date('O')/100))));
-						$user_digest_last_sent = ($row['user_digest_last_sent'] == 0) ? $this->language->lang('DIGESTS_NO_DIGESTS_SENT') : strftime($this->helper->dateFormatToStrftime($this->user->data['user_dateformat'], $this->user->data['user_lang']), $row['user_digest_last_sent'] + (60 * 60 * ($my_time_zone - (date('O')/100))));
+						$user_lastvisit = ($row['user_lastvisit'] == 0) ? $this->language->lang('DIGESTS_NEVER_VISITED') : $this->helper->date_loc($this->user->data['user_dateformat'], $row['user_lastvisit'] + (60 * 60 * ($my_time_zone - (date('O')/100))));
+						$user_digest_last_sent = ($row['user_digest_last_sent'] == 0) ? $this->language->lang('DIGESTS_NO_DIGESTS_SENT') : $this->helper->date_loc($this->user->data['user_dateformat'], $row['user_digest_last_sent'] + (60 * 60 * ($my_time_zone - (date('O')/100))));
 					}
 
 					$this->template->assign_block_vars('digests_edit_subscribers', array(

--- a/cron/task/digests.php
+++ b/cron/task/digests.php
@@ -841,7 +841,7 @@ class digests extends \phpbb\cron\task\base
 			// because the messenger class is too dumb to do more than basic templating. Note: most language variables are handled automatically by the templating
 			// system.
 
-			$publish_date = (substr($row['user_lang'],0,2) == 'en') ? $this->language->lang('DIGESTS_PUBLISH_DATE', $row['username'], date(str_replace('|','',$row['user_dateformat']), $recipient_time)) : $this->language->lang('DIGESTS_PUBLISH_DATE', $row['username'], strftime($this->helper->dateFormatToStrftime($row['user_dateformat'], $row['user_lang']), $recipient_time));
+			$publish_date = $this->language->lang('DIGESTS_PUBLISH_DATE', $row['username'], $this->helper->date_loc($row['user_dateformat'], $recipient_time));
 
 			$html_messenger->assign_vars(array(
 				'S_CONTENT_DIRECTION'					=> $this->language->lang('DIRECTION'),
@@ -1295,7 +1295,7 @@ class digests extends \phpbb\cron\task\base
 				$pm_time_offset = ((int) $this->helper->make_tz_offset($user_row['user_timezone']) - (int) $this->server_timezone) * 60 * 60;
 				$recipient_time = $pm_row['message_time'] + $pm_time_offset;
 
-				$message_datetime = (substr($user_row['user_lang'],0,2) == 'en') ? date(str_replace('|', '', $user_row['user_dateformat']), $recipient_time) : strftime($this->helper->dateFormatToStrftime($user_row['user_dateformat'], $user_row['user_lang']), $recipient_time);
+				$message_datetime = $this->helper->date_loc($user_row['user_dateformat'], $recipient_time);
 
 				// Add to table of contents array
 				$this->toc['pms'][$this->toc_pm_count]['message_id'] = html_entity_decode($pm_row['msg_id']);
@@ -1919,7 +1919,7 @@ class digests extends \phpbb\cron\task\base
 				$post_time_offset = ((int) $this->helper->make_tz_offset($user_row['user_timezone']) - (int) $this->server_timezone) * 60 * 60;
 				$recipient_time = $post_row['post_time'] + $post_time_offset;
 
-				$post_datetime = (substr($user_row['user_lang'],0,2) == 'en') ? date(str_replace('|', '', $user_row['user_dateformat']), $recipient_time) : strftime($this->helper->dateFormatToStrftime($user_row['user_dateformat'], $user_row['user_lang']), $recipient_time);
+				$post_datetime = $this->helper->date_loc($user_row['user_dateformat'], $recipient_time);
 
 				// Add to table of contents array
 				$this->toc['posts'][$this->toc_post_count]['post_id'] = html_entity_decode($post_row['post_id']);

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -37,6 +37,8 @@ $lang = array_merge($lang, array(
 	'DIGESTS_COUNT_LIMIT_EXPLAIN'		=> 'Enter a number greater than zero if you want to limit the number of posts in the digest.',
 	'DIGESTS_DAILY'						=> 'Daily',
 	'DIGESTS_DATE'						=> 'Date',
+	'DIGESTS_DAYS_LONG'					=> 'Monday,Tuesday,Wednesday,Thursday,Friday,Saturday,Sunday',
+	'DIGESTS_DAYS_SHORT'				=> 'Mon,Tue,Wed,Thu,Fri,Sat,Sun',
 	'DIGESTS_DELIMITER'					=> ' :: ', // Used to help show the hierarchy of forum names from the index on down
 	'DIGESTS_DISABLED_MESSAGE'			=> 'To enable fields, select Basics and select a digest type',
 	'DIGESTS_DISCLAIMER'				=> 'This digest is being sent to registered members of <a href="%1$s">%2$s</a> forums. You can change or delete your subscription from the forum&apos;s <a href="%1$sucp.%2$s">User Control Panel</a>. If you have questions or feedback on your digests please send it to the <a href="mailto:%1$s?subject=Digests">%2$s webmaster</a>.',
@@ -75,6 +77,8 @@ $lang = array_merge($lang, array(
 	'DIGESTS_MIN_SIZE'					=> 'Minimum words required in post for the post to appear in a digest',
 	'DIGESTS_MIN_SIZE_EXPLAIN'			=> 'If you leave this blank or set to 0, posts with text of any number of words are included.',
 	'DIGESTS_MONTHLY'					=> 'Monthly',
+	'DIGESTS_MONTHS_LONG'				=> 'January,February,March,April,May,June,July,August,September,October,November,December',
+	'DIGESTS_MONTHS_SHORT'				=> 'Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec',
 	'DIGESTS_NEW'						=> 'New',
 	'DIGESTS_NEW_POSTS_ONLY'			=> 'Show new posts only',
 	'DIGESTS_NEW_POSTS_ONLY_EXPLAIN'	=> 'This will filter out any posts posted prior to the date and time you last visited this board. If you visit the board frequently and read most of the posts, this will keep redundant posts from appearing in your digest. It may also mean that you will miss some posts in forums that you did not read.',

--- a/language/en/email/digests_html.txt
+++ b/language/en/email/digests_html.txt
@@ -85,11 +85,12 @@
 			{L_DIGESTS_BLOCK_IMAGES}{L_COLON} <!-- IF S_DIGESTS_BLOCK_IMAGES -->{L_YES}<!-- ELSE-->{L_NO}<!-- ENDIF--><br />
 			{L_DIGESTS_TOC}{L_COLON} <!-- IF S_DIGESTS_TOC -->{L_YES}<!-- ELSE-->{L_NO}<!-- ENDIF-->
 		</div></blockquote>
-		<hr />
-		<p><span class="copyright"><em>{S_DIGESTS_PUBLISH_DATE}</em></span></p>
-		<p>{S_DIGESTS_DISCLAIMER}</p>
-		<p><span class="copyright">{L_DIGESTS_POWERED_BY_TEXT} {S_DIGESTS_POWERED_BY}{S_DIGESTS_TRANSLATOR}</span></p>
-		
+		<div class="author">
+			<hr />
+			<p><span class="copyright"><em>{S_DIGESTS_PUBLISH_DATE}</em></span></p>
+			<p>{S_DIGESTS_DISCLAIMER}</p>
+			<p><span class="copyright">{L_DIGESTS_POWERED_BY_TEXT} {S_DIGESTS_POWERED_BY}{S_DIGESTS_TRANSLATOR}</span></p>
+		</div>
 	</div>
 </div>
 </body>


### PR DESCRIPTION
strftime cannot express all markup of date(), although it supports localized names of weekdays and months. Additionally on Windows different strings have to be used depending on Windows version. date_loc function introduced to enhance date formatting by using months and weekdays from language strings.