### PR TITLE
Email queue not saved

### DIFF
--- a/cron/task/digests.php
+++ b/cron/task/digests.php
@@ -1179,6 +1179,9 @@ class digests extends \phpbb\cron\task\base
 					}
 					else
 					{
+						// save queue for later delivery (if applicable)
+						$html_messenger->save_queue();
+
 						// Digest should have been mailed successfully
 						if ($this->config['phpbbservices_digests_enable_log'])
 						{


### PR DESCRIPTION
Because the email queue is not saved, the queued emails are lost and the cron task cannot deliver the emails.

Note: The queue is now saved after each mail generated. The save could be called only once after all emails are generated. But in case the script is terminated because of an error or execution timeout, all the emails would be lost.