### PR TITLE
Limit image sizes to container size.

### DIFF
--- a/language/en/email/digests_html.txt
+++ b/language/en/email/digests_html.txt
@@ -37,6 +37,7 @@
 		tr:nth-child(even), .post:nth-child(even) { background: #FFF; }
 		tr:nth-child(odd), .post:nth-child(odd) { background: #EBEADD; }
 		#wrap { padding-right: 5px; padding-left: 5px; }
+		img { max-width: 100%; max-height: auto; }
 	</style>
 
 </head>


### PR DESCRIPTION
This extension is heavily used in one of my clients forums. After we  increased image size limit it caused styling problems with our digests.

If this is something you would like I can add it to all languages.